### PR TITLE
Adding support for Casper JUnit output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    res (1.1.0.pre)
+    res (1.1.0.pre2)
       hive-messages (~> 1)
       json (~> 1.8)
       ox (~> 2.2)
@@ -24,6 +24,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.2)
+    coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     descendants_tracker (0.0.4)
@@ -41,11 +42,16 @@ GEM
     i18n (0.7.0)
     ice_nine (0.11.1)
     json (1.8.3)
+    method_source (0.8.2)
     mimemagic (0.3.0)
-    minitest (5.8.2)
+    minitest (5.8.3)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     ox (2.2.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     representable (2.3.0)
       uber (~> 0.0.7)
     roar (1.0.3)
@@ -63,6 +69,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    slop (3.6.0)
     test_rail-api (0.4.0)
       json (~> 1.0)
       virtus (~> 1.0)
@@ -80,5 +87,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   res!
   rspec (~> 3.2)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Note: This cucumber formatter works for cucumber version < 2.0
     ./bin/res.rb --junit '/path/to/xunit_result.xml'
 Note: The Res output of the xunit parser is saved in the current directory
 
+## Casper
+    ./bin/res.rb --junitcasper '/path/to/xunit_result.xml'
+Note: The Res output of the xunit parser is saved in the current directory
+
 ## Reporters
 
 There are a number of backend reporters, for taking IR and producing a report from

--- a/bin/res.rb
+++ b/bin/res.rb
@@ -5,6 +5,7 @@ require 'res/reporters/testmine'
 require 'res/reporters/test_rail'
 require 'res/reporters/hive'
 require 'res/parsers/junit'
+require 'res/parsers/junitcasper'
 require 'openssl'
 
 class CLIParser
@@ -13,18 +14,18 @@ class CLIParser
   # Return a structure describing the options.
   #
   def self.parse(args)
-    
+
     # Default values
     options = OpenStruct.new
 
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: res [options]"
- 
+
       opts.on("-r", "--res RES_FILE",
               "res file to load") do |res|
         options.res = res
       end
-      
+
       opts.on("-s", "--submit REPORTER",
               "Reporter to use to submit results") do |reporter|
         options.reporter = reporter
@@ -33,6 +34,11 @@ class CLIParser
       opts.on("--junit junit_xml",
               "Parse junit xml to res type") do |junit|
         options.junit = junit
+      end
+
+      opts.on("--junitcasper junit_xml",
+              "Parse junit xml to res type") do |junitcasper|
+        options.junitcasper = junitcasper
       end
 
       opts.on("--cert CERT",
@@ -69,12 +75,12 @@ class CLIParser
               "VERSION of the world under test") do |version|
         options.version = version
       end
-      
+
       opts.on("--target TARGET",
               "Target of execution (e.g. Chrome)") do |target|
         options.target = target
       end
-      
+
       opts.on_tail("-h", "--help", "Display help") do
         puts opts
         exit
@@ -84,8 +90,8 @@ class CLIParser
 
     opt_parser.parse!(args)
     options
-  end 
-end 
+  end
+end
 
 options = CLIParser.parse(ARGV)
 
@@ -95,49 +101,54 @@ if options.res
 end
 
 if options.junit
-    junit_output = Res::Parsers::Junit.new(options.junit)
-    ir = Res::IR.load(junit_output.io)
-end 
+  junit_output = Res::Parsers::Junit.new(options.junit)
+  ir = Res::IR.load(junit_output.io)
+end
+
+if options.junitcasper
+  junit_output = Res::Parsers::Junitcasper.new(options.junitcasper)
+  ir = Res::IR.load(junit_output.io)
+end
 
 raise "No results loaded" if !ir
 
 if options.reporter
   case options.reporter
-  when 'hive'
-    
-    raise "Need to provide a hive job_id" if !options.job_id
-    
-    reporter = Res::Reporters::Hive.new(
-      :url => options.url,
-      :cert => options.cert,
-      :cacert => options.cacert,
-      :ssl_verify_mode => options.ssl_verify_mode
-    )
-    
-    reporter.submit_results( ir, :job_id => options.job_id )
-  when 'testmine'
-    
-    reporter = Res::Reporters::Testmine.new(
-      :config_file => options.config_file,
-      :version     => options.version,
-      :target      => options.target,
-      :url         => options.url
-    )
-    
-    id = reporter.submit_results(ir)
-    puts "Reported to testmine: #{id}"
-  when 'testrail'
-    reporter = Res::Reporters::TestRail.new(
-      :config_file => options.config_file,
-      :target      => options.target,
-      :url         => options.url,
-      :ir          => ir
-    )
- 
-    output = reporter.submit_results(ir)
-    puts output
-  else
+    when 'hive'
 
-    raise "#{options.reporter} not implemented"
+      raise "Need to provide a hive job_id" if !options.job_id
+
+      reporter = Res::Reporters::Hive.new(
+          :url => options.url,
+          :cert => options.cert,
+          :cacert => options.cacert,
+          :ssl_verify_mode => options.ssl_verify_mode
+      )
+
+      reporter.submit_results( ir, :job_id => options.job_id )
+    when 'testmine'
+
+      reporter = Res::Reporters::Testmine.new(
+          :config_file => options.config_file,
+          :version     => options.version,
+          :target      => options.target,
+          :url         => options.url
+      )
+
+      id = reporter.submit_results(ir)
+      puts "Reported to testmine: #{id}"
+    when 'testrail'
+      reporter = Res::Reporters::TestRail.new(
+          :config_file => options.config_file,
+          :target      => options.target,
+          :url         => options.url,
+          :ir          => ir
+      )
+
+      output = reporter.submit_results(ir)
+      puts output
+    else
+
+      raise "#{options.reporter} not implemented"
   end
 end

--- a/lib/res.rb
+++ b/lib/res.rb
@@ -7,23 +7,23 @@ module Res
   def self.submit_results(args)
     reporter_class = Res.reporter_class(args[:reporter])
     reporter = reporter_class.new( args )
-    
+
     ir = Res::IR.load(args[:ir])
-    
+
     reporter.submit_results( ir, args )
   end
 
   def self.reporter_class(type)
     case type
-    when :test_rail
-      require 'res/reporters/test_rail'
-      Res::Reporters::TestRail
-    when :hive
-      require 'res/reporters/hive'
-      Res::Reporters::Hive
-    when :testmine
-      require 'res/reporters/testmine'
-      Res::Reporters::Testmine
+      when :test_rail
+        require 'res/reporters/test_rail'
+        Res::Reporters::TestRail
+      when :hive
+        require 'res/reporters/hive'
+        Res::Reporters::Hive
+      when :testmine
+        require 'res/reporters/testmine'
+        Res::Reporters::Testmine
     end
   end
 
@@ -34,11 +34,14 @@ module Res
 
   def self.parser_class(type)
     case type
-    when :junit
-      require 'res/parsers/junit'
-      Res::Parsers::Junit
-    else
-      raise "#{type} parser not Implemented"
+      when :junit
+        require 'res/parsers/junit'
+        Res::Parsers::Junit
+      when :junitcasper
+        require 'res/parsers/junitcasper'
+        Res::Parsers::Junitcasper
+      else
+        raise "#{type} parser not Implemented"
     end
   end
 

--- a/lib/res/parsers/junitcasper.rb
+++ b/lib/res/parsers/junitcasper.rb
@@ -1,0 +1,98 @@
+require 'ox'
+require 'json'
+require 'res/ir'
+
+module Res
+  module Parsers
+    class Junitcasper
+      attr_accessor :io
+
+      def initialize(junit_xml)
+        file = File.open(junit_xml, "rb")
+        begin
+          junit = Ox.parse(file.read)
+        rescue Ox::ParseError => e
+          raise "Invalid xunit XML format. Error: #{e}"
+        end
+        file.close
+        @test_suites = create_test_suites(packagenames(junit))
+        junit.nodes.collect do |test_suites|
+          create_multiple_test_suite(test_suites)
+        end
+        ir = ::Res::IR.new(:type => 'Casper',
+                           :started => "",
+                           :finished => Time.now(),
+                           :results => @test_suites
+        )
+
+        @io = File.open("./junitcasper.res", "w")
+        @io.puts ir.json
+        @io.close
+      end
+
+      def test_case(suite)
+        testcases = Hash.new
+        testcases = suite.nodes.collect do |node|
+          if node.value == "testcase"
+            testcase = Hash.new
+            testcase[:type] = "Casper::" + node.value
+            testcase[:name] = truncateName(node.attributes[:name])
+            testcase["duration"] = node.attributes[:time]
+            testcase["status"] = "passed"
+            if node.nodes[0] != nil
+              testcase["status"] = "failed" if node.nodes[0].value == "failure" or node.nodes[0].value == "error"
+              testcase["status"] = "notrun" if node.nodes[0].value == "skipped"
+            end
+            testcase
+          end
+        end
+        testcases.compact
+      end
+
+      def create_multiple_test_suite(suites)
+        i = 0
+        suites.nodes.each_with_index do |suite, index|
+          test_suite = Hash.new
+          test_suite[:type] = "Casper::testsuite"
+          test_suite[:name] = suite.attributes[:name]
+          test_suite[:children] = Array.new
+          test_suite[:children] = test_case(suite)
+          i = @test_suites.index { |test_suites|
+            test_suites[:name] == suite.attributes[:package]
+          }
+          @test_suites[i][:children].push(test_suite)
+        end
+      end
+
+      def create_test_suites (pkgnames)
+        test_suites= Array.new
+        pkgnames.each_with_index do |pkgname, index|
+          test_suites[index] = Hash.new
+          test_suites[index][:type]= "Casper::testsuites"
+          test_suites[index][:name]= pkgname
+          test_suites[index][:children] = Array.new
+        end
+        test_suites
+      end
+
+
+      def packagenames (junit)
+        packagename=junit.nodes[0].nodes.collect do |node|
+          node.attributes[:package]
+        end
+        packagename.uniq
+      end
+
+      def truncateName(inputText)
+        if inputText.to_s.empty? ==false
+          return inputText[0..253]#.gsub(/\s+$/, '')
+        else
+          return inputText
+        end
+      end
+
+
+    end # class JUnit
+  end # class Parsers
+end # class Res
+


### PR DESCRIPTION
This is to add support for Casper JUnit ouput.
We are using the standard casper xunit output but it isn’t very nice when you use the standard JUnit parser for res.
This creates much nicer representation.

JUnit gives you one ‘Suites’ but we want to use the files the tests have come from as the ‘Suites’. So we do this using the packagenames function to find unique packagenames on the individual suites and
create a list of them.

JUnit also gives you a system-out in every test suite. We’re just checking for testcases inside the suites so we don’t get these anymore.

We have also restricted the length of the names of testsuties to ensure they fit into databases. I think we may want to improve on this in the future.

This work was done very much in conjunction with:
https://github.com/Asimk21