### PR TITLE
Allow using env variables in config with ERB

### DIFF
--- a/lib/res/formatters/rspec.rb
+++ b/lib/res/formatters/rspec.rb
@@ -65,11 +65,11 @@ module Res
         set_status(result, test.metadata[:location], status)
       end
 
-        def add_result(test)
-       return { 
-          "type": "Rspec::Test",
-          "name": test[:description],
-          "urn": test[:location],
+      def add_result(test)
+        {
+          'type' => 'Rspec::Test',
+          'name' => test[:description],
+          'urn'  => test[:location]
         }
       end
 
@@ -123,7 +123,7 @@ module Res
         @ir = ::Res::IR.new( :type        => 'Rspec',
                             :started     => @start_time,
                             :results     => result,
-                            :finished    => Time.now(),
+                            :finished    => Time.now()
                             )
       end
 


### PR DESCRIPTION
Being able to use environment variables for credentials would make it less likely for someone to commit credentials to git and instead pass them through from the CI.