### PR TITLE
Make add_result hash syntax work with Ruby 2.1

### DIFF
--- a/lib/res/formatters/rspec.rb
+++ b/lib/res/formatters/rspec.rb
@@ -65,11 +65,11 @@ module Res
         set_status(result, test.metadata[:location], status)
       end
 
-        def add_result(test)
-       return { 
-          "type": "Rspec::Test",
-          "name": test[:description],
-          "urn": test[:location],
+      def add_result(test)
+        {
+          'type' => 'Rspec::Test',
+          'name' => test[:description],
+          'urn'  => test[:location]
         }
       end
 
@@ -123,7 +123,7 @@ module Res
         @ir = ::Res::IR.new( :type        => 'Rspec',
                             :started     => @start_time,
                             :results     => result,
-                            :finished    => Time.now(),
+                            :finished    => Time.now()
                             )
       end
 

--- a/lib/res/formatters/rspec.rb
+++ b/lib/res/formatters/rspec.rb
@@ -67,9 +67,9 @@ module Res
 
       def add_result(test)
         {
-          'type' => 'Rspec::Test',
-          'name' => test[:description],
-          'urn'  => test[:location]
+          type: "Rspec::Test",
+          name: test[:description],
+          urn: test[:location]
         }
       end
 


### PR DESCRIPTION
The syntax for the add_result hash seems to only work with Ruby 2.2 while the old hashrocket syntax works with any version.