### PR TITLE
Adding the current time as the start time to casperjunit parser

### DIFF
--- a/lib/res/parsers/junitcasper.rb
+++ b/lib/res/parsers/junitcasper.rb
@@ -20,7 +20,7 @@ module Res
           create_multiple_test_suite(test_suites)
         end
         ir = ::Res::IR.new(:type => 'Casper',
-                           :started => "",
+                           :started => Time.now(),
                            :finished => Time.now(),
                            :results => @test_suites
         )


### PR DESCRIPTION
This is a very tiny change to add the current time as the start time for the casperjunit parser
There are potentially better ways we can do this because it's therefore using the time of the import as the starttime, I'd like to get something in so we can start to use this in anger though.
BrassDuke