### PR TITLE
Ensure formatter works with cucumber 2.0.2

### DIFF
--- a/lib/res/formatters/ruby_cucumber2.rb
+++ b/lib/res/formatters/ruby_cucumber2.rb
@@ -14,7 +14,11 @@ module Res
      
       def initialize(runtime, path_or_io, options)
         @runtime = runtime
-        @io = ensure_io(path_or_io) 
+        begin
+		@io = ensure_io(path_or_io) 
+	rescue
+		@io = ensure_io(path_or_io, '')
+	end
         @options = options
         @exceptions = []
         @indent = 0

--- a/lib/res/formatters/ruby_cucumber2.rb
+++ b/lib/res/formatters/ruby_cucumber2.rb
@@ -15,10 +15,10 @@ module Res
       def initialize(runtime, path_or_io, options)
         @runtime = runtime
         begin
-		      @io = ensure_io(path_or_io) 
-	      rescue
-		      @io = ensure_io(path_or_io, '')
-	      end
+         @io = ensure_io(path_or_io) 
+        rescue
+         @io = ensure_io(path_or_io, '')
+        end
         @options = options
         @exceptions = []
         @indent = 0
@@ -216,7 +216,7 @@ module Res
       end
 
       def after_table_row(table_row)
-	if table_row.class == Cucumber::Formatter::LegacyApi::Ast::ExampleTableRow
+ if table_row.class == Cucumber::Formatter::LegacyApi::Ast::ExampleTableRow
 
           @_current_table_row[:name] = table_row.name
           if table_row.exception

--- a/lib/res/formatters/ruby_cucumber2.rb
+++ b/lib/res/formatters/ruby_cucumber2.rb
@@ -15,10 +15,10 @@ module Res
       def initialize(runtime, path_or_io, options)
         @runtime = runtime
         begin
-         @io = ensure_io(path_or_io) 
+          @io = ensure_io(path_or_io) 
         rescue
-         @io = ensure_io(path_or_io, '')
-       end
+          @io = ensure_io(path_or_io, '')
+        end
         @options = options
         @exceptions = []
         @indent = 0

--- a/lib/res/formatters/ruby_cucumber2.rb
+++ b/lib/res/formatters/ruby_cucumber2.rb
@@ -15,10 +15,10 @@ module Res
       def initialize(runtime, path_or_io, options)
         @runtime = runtime
         begin
-		@io = ensure_io(path_or_io) 
-	rescue
-		@io = ensure_io(path_or_io, '')
-	end
+		      @io = ensure_io(path_or_io) 
+	      rescue
+		      @io = ensure_io(path_or_io, '')
+	      end
         @options = options
         @exceptions = []
         @indent = 0

--- a/lib/res/formatters/ruby_cucumber2.rb
+++ b/lib/res/formatters/ruby_cucumber2.rb
@@ -18,7 +18,7 @@ module Res
          @io = ensure_io(path_or_io) 
         rescue
          @io = ensure_io(path_or_io, '')
-        end
+       end
         @options = options
         @exceptions = []
         @indent = 0
@@ -216,7 +216,7 @@ module Res
       end
 
       def after_table_row(table_row)
- if table_row.class == Cucumber::Formatter::LegacyApi::Ast::ExampleTableRow
+        if table_row.class == Cucumber::Formatter::LegacyApi::Ast::ExampleTableRow
 
           @_current_table_row[:name] = table_row.name
           if table_row.exception


### PR DESCRIPTION
In Cucumber v 2.0.2 it used to be Cucumber::Formatter::IO.ensure_io(path_or_io, path)
changed to 
[Cucumber v 2.3.3](https://github.com/cucumber/cucumber-ruby/blob/b781bbf6b99d1d127e3468399a7e335f3cc99b5e/lib/cucumber/formatter/io.rb#L6)