### PR TITLE
Allow count/total results

### DIFF
--- a/lib/res/reporters/lion.rb
+++ b/lib/res/reporters/lion.rb
@@ -21,6 +21,15 @@ module Res
         status = "failed"
         status = "passed" if ir.tests.count == ir.count(:passed)
 
+        if ir.values.has_key?('#type') && ir.values['#type'] == 'multiple'
+          measures = {}
+          ir.values.select { |k, v| k !~ /^[#_]/ }.each do |k, v|
+            measures[k] = { :count => v, :total => ir.values['_total'] }
+          end
+        else
+          measures = ir.values
+        end
+
         # Set Lion Data
         lion_data = {
           :app_name => config.app_name,
@@ -32,9 +41,8 @@ module Res
           :started => ir.results.first[:started],
           :finished => ir.results.last[:finished],
           :status => status,
-          :measures => ir.values
+          :measures => measures
         }
-        
         
         uri = URI.parse(config.url)
         @http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/res/version.rb
+++ b/lib/res/version.rb
@@ -1,3 +1,3 @@
 module Res
-  VERSION = '1.2.11'
+  VERSION = '1.2.12'
 end


### PR DESCRIPTION
If an entry in the values section in the res format is:

```
{
  "Value name": (integer - successful tests),
  "_total": (integer - total number of tests),
  "#type": multiple
}
```

then the results will be submitted as:

"Value name:" {
  count: (integer - successful tests),
  total: (integer - total number of tests)
}

rather than a single value, as in the normal case.